### PR TITLE
$onlyMainQuery is undefined

### DIFF
--- a/source/php/FallbackQuery.php
+++ b/source/php/FallbackQuery.php
@@ -36,7 +36,7 @@ class FallbackQuery
     {
 
         //If class is set to only fallback on main query, return false if it's not this one.
-        if ($onlyMainQuery && !$query->is_main_query()) {
+        if ($this->onlyMainQuery && !$query->is_main_query()) {
             return false;
         }
 


### PR DESCRIPTION
`$onlyMainQuery` is undefined in the `fallbackToLanguageSingle` function context and throws errors. replacing by `$this->onlyMainQuery` as defined in __contruct solves the error.